### PR TITLE
feat: shopify connector

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/source_shopify/streams/base_streams.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/streams/base_streams.py
@@ -148,8 +148,8 @@ class ShopifyDeletedEventsStream(ShopifyStream):
                 "id": event["subject_id"],
                 self.cursor_field: event["created_at"],
                 "updated_at": event["created_at"],
-                "deleted_message": event["message"],
-                "deleted_description": event["description"],
+                "deleted_message": event.get("message", None),
+                "deleted_description": event.get("description", None),
                 "shop_url": event["shop_url"],
             }
 

--- a/python
+++ b/python
@@ -1,1 +1,0 @@
-/usr/local/bin/python3.10

--- a/python
+++ b/python
@@ -1,0 +1,1 @@
+/usr/local/bin/python3.10


### PR DESCRIPTION
Snapshot of a previous version of the shopify connector.

No need to rebase. This is for visibility only.